### PR TITLE
Add globalObject to webpack config output

### DIFF
--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -10,6 +10,7 @@ module.exports = {
   output: {
     path: libPath,
     filename: "qr-code-styling.js",
+    globalObject: "this",
     library: "QRCodeStyling",
     libraryTarget: "umd",
     libraryExport: "default"


### PR DESCRIPTION
This PR fixes #38 by adding the `globalObject` output setting in the common webpack config. Per [webpack's docs](https://webpack.js.org/configuration/output/#outputglobalobject): 

> When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets. 

This change replaces the instance of `self` in the built output to become `this`, which works in both node and browser environments. 