### PR TITLE
Added: xlink:href

### DIFF
--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -507,6 +507,7 @@ export default class QRSVG {
 
     const image = this._window.document.createElementNS("http://www.w3.org/2000/svg", "image");
     image.setAttribute("href", this._imageUri || "");
+    image.setAttribute("xlink:href", this._imageUri || "");
     image.setAttribute("x", String(dx));
     image.setAttribute("y", String(dy));
     image.setAttribute("width", `${dw}px`);


### PR DESCRIPTION
To fix the issue of the png image not rendering in Adobe Illustrator for downloaded .svg QR files.

It appears Adobe Illustrator still needs the xlink:href value to render the png image in the center of the QR code.
- https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xlink:href

No xlink:
![qr-code-styling](https://github.com/user-attachments/assets/b770b92b-ab29-4b3d-9712-f92708e740d1)
![current-illustrator](https://github.com/user-attachments/assets/9041e2f4-9b8a-4b0a-88ea-faf5da6468d1)

With xlink:
![qr-code-styling - xlink](https://github.com/user-attachments/assets/e37e683c-2f4d-4804-a757-c08a94480557)
![xlink-illustrator](https://github.com/user-attachments/assets/9fa8d20d-a4e0-47a4-8151-da102a72c33e)
