### PR TITLE
fix: svg image hanging on 404 or any error

### DIFF
--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -481,6 +481,7 @@ export default class QRSVG {
           }
           resolve();
         };
+        image.onerror = reject;
         image.src = options.image;
       }
     });


### PR DESCRIPTION
When creating a SVG QR code the library halt with an image which could not be loaded. Adding an error handler fixes this.