### PR TITLE
fix: Remove quotes from SVG url() attributes

### DIFF
--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -541,7 +541,7 @@ export default class QRSVG {
     rect.setAttribute("y", String(y));
     rect.setAttribute("height", String(height));
     rect.setAttribute("width", String(width));
-    rect.setAttribute("clip-path", `url('#clip-path-${name}')`);
+    rect.setAttribute("clip-path", `url(#clip-path-${name})`);
 
     if (options) {
       let gradient: SVGElement;
@@ -603,7 +603,7 @@ export default class QRSVG {
         gradient.appendChild(stop);
       });
 
-      rect.setAttribute("fill", `url('#${name}')`);
+      rect.setAttribute("fill", `url(#${name})`);
       this._defs.appendChild(gradient);
     } else if (color) {
       rect.setAttribute("fill", color);


### PR DESCRIPTION
related issue #309 