### PR TITLE
Add support for raw SVG + avoid fixed size

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ height                 | number                     |`300`    |Size of canvas
 type                   | string (`'canvas' 'svg'`)  |`canvas` |The type of the element that will be rendered
 shape                  | string (`'square' 'circle')|`square` |The shape of the qr-code, circle shape adds rundom extra dots arround
 data                   | string                     |         |The data will be encoded to the QR code
-image                  | string                     |         |The image will be copied to the center of the QR code
+image                  | string                     |         |The image will be copied to the center of the QR code. It should be a URL to an image file or a raw SVG string if using `rawSvg`.
 margin                 | number                     |`0`      |Margin around canvas
 qrOptions              | object                     |         |Options will be passed to `qrcode-generator` lib
 imageOptions           | object                     |         |Specific image options, details see below
@@ -133,8 +133,10 @@ Property          |Type                                   | Default Value |Descr
 hideBackgroundDots|boolean                                | `true`        |Hide all dots covered by the image
 imageSize         |number                                 | `0.4`         |Coefficient of the image size. Not recommended to use ove 0.5. Lower is better
 margin            |number                                 | `0`           |Margin of the image in px
-crossOrigin       |string(`'anonymous' 'use-credentials'`)|               |Set "anonymous" if you want to download QR code from other origins.
-saveAsBlob        |boolean                                | `true`        |Saves image as base64 blob in svg type, see bellow
+crossOrigin       |string(`'anonymous' 'use-credentials'`)|               |Set "anonymous" if you want to download QR code from other origins. Ignored if `rawSvg` is `true`.
+saveAsBlob        |boolean                                | `true`        |Saves image as base64 blob in SVG type. See below. Ignored if `rawSvg` is `true`.
+rawSvg            |boolean                                | `false`       |If true, the `image` property must be a raw SVG string. `saveAsBlob` is ignored.
+svgAspectRatio    |number                                 | `1`           |When using raw SVG, provide the aspect ratio of the SVG (width/height) in order to correctly calculate which dots will be covered.
 
 When QR type is svg, the image may not load in certain applications as it is saved as a url, and some svg applications will not render url images for security reasons. Setting `saveAsBlob` to true will instead save the image as a blob, allowing it to render correctly in more places, but will also increase the file size.
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ type                   | string (`'canvas' 'svg'`)  |`canvas` |The type of the e
 shape                  | string (`'square' 'circle')|`square` |The shape of the qr-code, circle shape adds rundom extra dots arround
 data                   | string                     |         |The data will be encoded to the QR code
 image                  | string                     |         |The image will be copied to the center of the QR code. It should be a URL to an image file or a raw SVG string if using `rawSvg`.
+fixedSize              | boolean                    |`true`   |Whether to add explicit width and height to the QR code SVG. Set to `false` to let the QR codes fit their container.
 margin                 | number                     |`0`      |Margin around canvas
 qrOptions              | object                     |         |Options will be passed to `qrcode-generator` lib
 imageOptions           | object                     |         |Specific image options, details see below

--- a/src/core/QROptions.ts
+++ b/src/core/QROptions.ts
@@ -22,6 +22,8 @@ export interface RequiredOptions extends Options {
     imageSize: number;
     crossOrigin?: string;
     margin: number;
+    rawSvg?: boolean,
+    svgAspectRatio?: number
   };
   dotsOptions: {
     type: DotType;
@@ -53,7 +55,9 @@ const defaultOptions: RequiredOptions = {
     hideBackgroundDots: true,
     imageSize: 0.4,
     crossOrigin: undefined,
-    margin: 0
+    margin: 0,
+    rawSvg: false,
+    svgAspectRatio: undefined
   },
   dotsOptions: {
     type: "square",

--- a/src/core/QROptions.ts
+++ b/src/core/QROptions.ts
@@ -9,6 +9,7 @@ export interface RequiredOptions extends Options {
   shape: ShapeType;
   width: number;
   height: number;
+  fixedSize: boolean;
   margin: number;
   data: string;
   qrOptions: {
@@ -43,6 +44,7 @@ const defaultOptions: RequiredOptions = {
   shape: shapeTypes.square,
   width: 300,
   height: 300,
+  fixedSize: true,
   data: "",
   margin: 0,
   qrOptions: {

--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -51,8 +51,10 @@ export default class QRSVG {
   constructor(options: RequiredOptions, window: Window) {
     this._window = window;
     this._element = this._window.document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    this._element.setAttribute("width", String(options.width));
-    this._element.setAttribute("height", String(options.height));
+    if (options.fixedSize) {
+      this._element.setAttribute("width", String(options.width));
+      this._element.setAttribute("height", String(options.height));
+    }
     this._element.setAttribute("xmlns:xlink", "http://www.w3.org/1999/xlink");
     if (!options.dotsOptions.roundSize) {
       this._element.setAttribute("shape-rendering", "crispEdges");

--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -43,6 +43,7 @@ export default class QRSVG {
   _image?: HTMLImageElement | Image;
   _imageUri?: string;
   _instanceId: number;
+  _rawSvg: boolean;
 
   static instanceCount = 0;
 
@@ -62,6 +63,7 @@ export default class QRSVG {
     this._imageUri = options.image;
     this._instanceId = QRSVG.instanceCount++;
     this._options = options;
+    this._rawSvg = options.imageOptions.rawSvg ?? false
   }
 
   get width(): number {
@@ -91,19 +93,20 @@ export default class QRSVG {
     this._qr = qr;
 
     if (this._options.image) {
-      //We need it to get image size
-      await this.loadImage();
-      if (!this._image) return;
+      if (!this._options.imageOptions.rawSvg) {
+        // We need it to get image size unless it's a raw SVG string.
+        await this.loadImage();
+        if (!this._image) return;
+      }
       const { imageOptions, qrOptions } = this._options;
       const coverLevel = imageOptions.imageSize * errorCorrectionPercents[qrOptions.errorCorrectionLevel];
       const maxHiddenDots = Math.floor(coverLevel * count * count);
-
       drawImageSize = calculateImageSize({
-        originalWidth: this._image.width,
-        originalHeight: this._image.height,
-        maxHiddenDots,
-        maxHiddenAxisDots: count - 14,
-        dotSize
+          originalWidth: imageOptions.rawSvg ? imageOptions.svgAspectRatio ?? 1 : (this._image?.width as number),
+          originalHeight:imageOptions.rawSvg ? 1 : (this._image?.height as number),
+          maxHiddenDots,
+          maxHiddenAxisDots: count - 14,
+          dotSize
       });
     }
 
@@ -506,8 +509,14 @@ export default class QRSVG {
     const dh = height - options.imageOptions.margin * 2;
 
     const image = this._window.document.createElementNS("http://www.w3.org/2000/svg", "image");
-    image.setAttribute("href", this._imageUri || "");
-    image.setAttribute("xlink:href", this._imageUri || "");
+    if (options.imageOptions.rawSvg) {
+        const encoded = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(options.image as string)}`;
+        image.setAttribute("href", encoded);
+        image.setAttribute("xlink:href", encoded);
+    } else {
+        image.setAttribute("href", this._imageUri || "");
+        image.setAttribute("xlink:href", this._imageUri || "");
+    }
     image.setAttribute("x", String(dx));
     image.setAttribute("y", String(dy));
     image.setAttribute("width", `${dw}px`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -129,6 +129,8 @@ export type Options = {
     imageSize?: number;
     crossOrigin?: string;
     margin?: number;
+    rawSvg?: boolean;
+    svgAspectRatio?: number
   };
   dotsOptions?: {
     type?: DotType;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -113,6 +113,7 @@ export type Options = {
   shape?: ShapeType;
   width?: number;
   height?: number;
+  fixedSize?: boolean;
   margin?: number;
   data?: string;
   image?: string;


### PR DESCRIPTION
Hello

I found it rather frustrating that I would have to host the image inside the QR code when it was a small SVG anyway.

With these changes, you can set `image` to a raw SVG string and it will draw that instead of trying to download the SVG. This also avoids issues with CORS.

This also lets you dynamically change the color of your QR code logo depending on the QR color (if you wanted to do that).
I.e. (empty SVG for demonstration)
```js
image: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="15 15 45 45" fill="${your_color_here}"><path fill="#fff"/></svg>`
```

In order to correctly calculate which dots to hide, I added `svgAspectRatio` as well, as the size of SVGs don't matter by definition, so this will be used to correctly calculate which dots would be covered by the SVG. I've tested this and it works. I couldn't get it to reliably render and extract the size of the SVG upfront - which also means all SVGs would get drawn twice if I'm not mistaken. It defaults to 1.