### PR TITLE
Replace direct node js types imports

### DIFF
--- a/src/core/QRCodeStyling.ts
+++ b/src/core/QRCodeStyling.ts
@@ -6,10 +6,9 @@ import drawTypes from "../constants/drawTypes";
 
 import defaultOptions, { RequiredOptions } from "./QROptions";
 import sanitizeOptions from "../tools/sanitizeOptions";
-import { FileExtension, QRCode, Options, DownloadOptions, ExtensionFunction, Window } from "../types";
+import { FileExtension, QRCode, Options, DownloadOptions, ExtensionFunction, Window, NodeCanvasElement } from "../types";
 import qrcode from "qrcode-generator";
 import getMimeType from "../tools/getMimeType";
-import { Canvas as NodeCanvas, Image } from "canvas";
 
 declare const window: Window;
 
@@ -18,7 +17,7 @@ export default class QRCodeStyling {
   _window: Window;
   _container?: HTMLElement;
   _domCanvas?: HTMLCanvasElement;
-  _nodeCanvas?: NodeCanvas;
+  _nodeCanvas?: NodeCanvasElement;
   _svg?: SVGElement;
   _qr?: QRCode;
   _extension?: ExtensionFunction;
@@ -79,7 +78,7 @@ export default class QRCodeStyling {
       const image64 = `data:${getMimeType('svg')};base64,${svg64}`;
 
       if (this._options.nodeCanvas?.loadImage) {
-        return this._options.nodeCanvas.loadImage(image64).then((image: Image) => {
+        return this._options.nodeCanvas.loadImage(image64).then((image) => {
           // fix blurry svg
           image.width = this._options.width;
           image.height = this._options.height;

--- a/src/core/QRSVG.ts
+++ b/src/core/QRSVG.ts
@@ -7,8 +7,7 @@ import QRCornerDot, { availableCornerDotTypes } from "../figures/cornerDot/QRCor
 import { RequiredOptions } from "./QROptions";
 import gradientTypes from "../constants/gradientTypes";
 import shapeTypes from "../constants/shapeTypes";
-import { DotType, QRCode, FilterFunction, Gradient, Window } from "../types";
-import { Image } from "canvas";
+import { DotType, QRCode, FilterFunction, Gradient, Window, NodeCanvasImage } from "../types";
 
 const squareMask = [
   [1, 1, 1, 1, 1, 1, 1],
@@ -40,7 +39,7 @@ export default class QRSVG {
   _cornersDotClipPath?: SVGElement;
   _options: RequiredOptions;
   _qr?: QRCode;
-  _image?: HTMLImageElement | Image;
+  _image?: HTMLImageElement | NodeCanvasImage;
   _imageUri?: string;
   _instanceId: number;
 
@@ -457,7 +456,7 @@ export default class QRSVG {
       if (options.nodeCanvas?.loadImage) {
         options.nodeCanvas
           .loadImage(options.image)
-          .then((image: Image) => {
+          .then((image) => {
             this._image = image;
             if (this._options.imageOptions.saveAsBlob) {
               const canvas = options.nodeCanvas?.createCanvas( this._image.width,  this._image.height);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,3 @@
-import { DOMWindow, JSDOM } from "jsdom";
-import nodeCanvas  from "canvas";
-
 export interface UnknownObject {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -14,7 +11,44 @@ export type GradientType = "radial" | "linear";
 export type DrawType = "canvas" | "svg";
 export type ShapeType = "square" | "circle";
 
-export type Window = DOMWindow;
+// Minimal window-like interface — compatible with both browser Window and jsdom DOMWindow
+export interface BrowserWindow {
+  document: Document;
+  XMLSerializer: typeof XMLSerializer;
+  Image: { new(): HTMLImageElement };
+  XMLHttpRequest: typeof XMLHttpRequest;
+  FileReader: typeof FileReader;
+}
+
+export type Window = BrowserWindow;
+
+// Minimal node-canvas interfaces — avoids importing the "canvas" package in browser bundles
+export interface NodeCanvasImage {
+  width: number;
+  height: number;
+}
+
+export interface NodeCanvasRenderingContext2D {
+  drawImage(image: NodeCanvasImage, dx: number, dy: number): void;
+}
+
+export interface NodeCanvasElement {
+  width: number;
+  height: number;
+  getContext(contextId: "2d"): NodeCanvasRenderingContext2D | null;
+  toBuffer(mimeType: string): Buffer;
+  toDataURL(type?: string): string;
+}
+
+export interface NodeCanvasFactory {
+  createCanvas(width: number, height: number): NodeCanvasElement;
+  loadImage(src: string): Promise<NodeCanvasImage>;
+}
+
+// Minimal jsdom constructor interface — avoids importing "jsdom" in browser bundles
+export interface JSDOMConstructor {
+  new(html: string, options?: { resources?: string }): { window: BrowserWindow };
+}
 
 export type Gradient = {
   type: GradientType;
@@ -116,8 +150,8 @@ export type Options = {
   margin?: number;
   data?: string;
   image?: string;
-  nodeCanvas?: typeof nodeCanvas;
-  jsdom?: typeof JSDOM;
+  nodeCanvas?: NodeCanvasFactory;
+  jsdom?: JSDOMConstructor;
   qrOptions?: {
     typeNumber?: TypeNumber;
     mode?: Mode;


### PR DESCRIPTION
## Problem

When attempting to integrate this library into a project I noticed I started receiving compilation errors due to dependencies in Node specific types, although my project is web only.

`src/types/index.ts`, `src/core/QRCodeStyling.ts`, and `src/core/QRSVG.ts` all contain top-level imports from `jsdom` and `canvas`, this prevents the library from being compiled correctly on projects with `skipLibCheck` set to true.

```ts
import { DOMWindow, JSDOM } from "jsdom";   // types/index.ts
import nodeCanvas from "canvas";            // types/index.ts
import { Canvas as NodeCanvas, Image } from "canvas"; // QRCodeStyling.ts
import { Image } from "canvas";             // QRSVG.ts
```

These are **Node.js-only** packages. Their presence as unconditional top-level imports causes two problems for browser consumers:

1. **Bundlers fail or warn** — webpack/vite/rollup try to resolve `jsdom` and `canvas` and either error out or produce warnings about missing Node built-ins.
2. **Generated `.d.ts` files reference the packages** — anyone using the published type declarations needs `@types/jsdom` and `canvas` installed, even for a browser-only project.

## Solution

Replace the three package imports with minimal **structural (duck-type) interfaces** defined inside the library itself:

| Old | New |
|-----|-----|
| `DOMWindow` from `jsdom` | `BrowserWindow` (document + XMLSerializer + Image + XMLHttpRequest + FileReader) |
| `typeof JSDOM` from `jsdom` | `JSDOMConstructor` |
| `typeof nodeCanvas` from `canvas` | `NodeCanvasFactory` |
| `Canvas` from `canvas` | `NodeCanvasElement` |
| `Image` from `canvas` | `NodeCanvasImage` |

The interfaces capture only the surface the library actually uses, so:

- Existing Node.js usage (`new QRCodeStyling({ nodeCanvas, jsdom })`) continues to work — the real `canvas` and `jsdom` objects satisfy the interfaces structurally.
- Browser bundles no longer see any reference to `jsdom` or `canvas`.
- Published `.d.ts` files no longer expose the external packages.

## Verification

```
npx tsc --noEmit   # 0 new errors (pre-existing @types/ws issue unchanged)
```